### PR TITLE
Update code block background highlight in hints and notes

### DIFF
--- a/site/_includes/reference.css
+++ b/site/_includes/reference.css
@@ -160,7 +160,7 @@ code, pre {
 }
 
 .desc-note pre, .desc-note code {
-    background-color: #edd8d8;
+    background-color: #ffdddd;
 }
 
 .desc-hint {
@@ -174,7 +174,7 @@ code, pre {
 }
 
 .desc-hint pre, .desc-hint code {
-    background-color: #d8d8ed;
+    background-color: #ddddff;
 }
 
 table.enum-values {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/02670f12-f753-42f3-bc13-08bd537d795f)

After:
![image](https://github.com/user-attachments/assets/2ff98b11-7fe7-4fb4-89e9-919c5c7562df)
